### PR TITLE
updating to use v3 dividends and splits API (with .gte .lte filters)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,9 +4,11 @@ authors = ["Bernard Brenyah and contributors"]
 version = "0.1.0"
 
 [deps]
+ConfigEnv = "01234589-554d-41b7-ae5c-7b6ee2db6796"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 JSONTables = "b9914132-a727-11e9-1322-f18e41205b0b"
+TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 
 [compat]
 HTTP = "0.9"

--- a/Project.toml
+++ b/Project.toml
@@ -5,10 +5,12 @@ version = "0.1.0"
 
 [deps]
 ConfigEnv = "01234589-554d-41b7-ae5c-7b6ee2db6796"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 JSONTables = "b9914132-a727-11e9-1322-f18e41205b0b"
 TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
+URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [compat]
 HTTP = "0.9"

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -5,7 +5,7 @@ The following endpoints are covered by the Reference API via these functions:
 * `tickers`                         => Tickers
 * `ticker_types`                    => Ticker Types
 * `ticker_details`                  => Ticker Details
-* `ticker_details_vX`               => Ticker Details vX
+* `ticker_details_v3`               => Ticker Details v3
 * `ticker_news`                     => Ticker News
 * `markets`                         => Markets
 * `locales`                         => Locales

--- a/src/PolygonIO.jl
+++ b/src/PolygonIO.jl
@@ -4,7 +4,8 @@ module PolygonIO
 using JSON3
 using JSONTables
 using HTTP
-
+using URIs
+using Dates
 
 ######### Import modules & utils ################
 include("custom_structs.jl")
@@ -20,10 +21,10 @@ include("streaming_socket.jl")
 
 ######### Global export of user API  ################
     # Reference API
-export PolyOpts, tickers, ticker_types, ticker_details, ticker_details_vX,
+export PolyOpts, tickers, ticker_types, ticker_details, ticker_details_v3,
         ticker_news, markets, locales, stock_splits, stock_dividends,
         stock_financials, market_holidays, market_status, stock_exchanges,
-        condition_mappings, crypto_exchanges,
+        condition_mappings, crypto_exchanges, ticker_to_figi,
 
     # Stock API
         stocks_trades, stocks_quotes_nbbo, stocks_last_trade_symbol, stocks_last_quote_symbol,

--- a/src/reference_api.jl
+++ b/src/reference_api.jl
@@ -252,7 +252,7 @@ julia> stock_splits(opts, "AAPL")
  * A JSON3.Array or specified tabular representation of the JSON3.Array.
  * See https://polygon.io/docs/get_v2_reference_splits__stocksTicker__anchor for documentation on response attributes and supported keyword arguments.
 """
-function stock_splits(opts::PolyOpts, stocksTicker::AbstractString, sort="execution_date", limit=1000, order="asc", kwargs...)
+function stock_splits(opts::PolyOpts, stocksTicker::AbstractString; sort="execution_date", limit=1000, order="asc", kwargs...)
     stock_splits_url = "$stock_splits_base_url"
     params = Dict(
         "ticker" => stocksTicker,
@@ -290,7 +290,7 @@ julia> stock_dividends(opts, "AAPL")
  * A JSON3.Array or specified tabular representation of the JSON3.Array.
  * See https://polygon.io/docs/get_v2_reference_dividends__stocksTicker__anchor for documentation on response attributes and supported keyword arguments.
 """
-function stock_dividends(opts::PolyOpts, stocksTicker::AbstractString, limit=1000, kwargs...)
+function stock_dividends(opts::PolyOpts, stocksTicker::AbstractString; limit=1000, kwargs...)
     stock_dividends_url = "$stock_dividends_base_url"
 
     params = Dict(

--- a/src/reference_api.jl
+++ b/src/reference_api.jl
@@ -257,7 +257,9 @@ function stock_splits(opts::PolyOpts, stocksTicker::AbstractString; sort="execut
     params = Dict(
         "ticker" => stocksTicker,
         "apiKey" => opts.api_key,
-        "limit" => limit
+        "limit" => limit,
+        "sort" => sort,
+        "order" => order
     )
 
     kwargs = Dict(String(k)=>v for (k,v) in pairs(Dict(kwargs)))

--- a/src/reference_api.jl
+++ b/src/reference_api.jl
@@ -252,7 +252,7 @@ julia> stock_splits(opts, "AAPL")
  * A JSON3.Array or specified tabular representation of the JSON3.Array.
  * See https://polygon.io/docs/get_v2_reference_splits__stocksTicker__anchor for documentation on response attributes and supported keyword arguments.
 """
-function stock_splits(opts::PolyOpts, stocksTicker::AbstractString; sort="execution_date", limit=1000, order="asc", kwargs...)
+function stock_splits(opts::PolyOpts, stocksTicker::AbstractString, sort="execution_date", limit=1000, order="asc", kwargs...)
     stock_splits_url = "$stock_splits_base_url"
     params = Dict(
         "ticker" => stocksTicker,
@@ -290,7 +290,7 @@ julia> stock_dividends(opts, "AAPL")
  * A JSON3.Array or specified tabular representation of the JSON3.Array.
  * See https://polygon.io/docs/get_v2_reference_dividends__stocksTicker__anchor for documentation on response attributes and supported keyword arguments.
 """
-function stock_dividends(opts::PolyOpts, stocksTicker::AbstractString; limit=1000, kwargs...)
+function stock_dividends(opts::PolyOpts, stocksTicker::AbstractString, limit=1000, kwargs...)
     stock_dividends_url = "$stock_dividends_base_url"
 
     params = Dict(

--- a/src/reference_api.jl
+++ b/src/reference_api.jl
@@ -252,9 +252,17 @@ julia> stock_splits(opts, "AAPL")
  * A JSON3.Array or specified tabular representation of the JSON3.Array.
  * See https://polygon.io/docs/get_v2_reference_splits__stocksTicker__anchor for documentation on response attributes and supported keyword arguments.
 """
-function stock_splits(opts::PolyOpts, stocksTicker::AbstractString)
-    stock_splits_url = "$stock_splits_base_url/$stocksTicker"
-    params = Dict("apiKey" => opts.api_key)
+function stock_splits(opts::PolyOpts, stocksTicker::AbstractString; sort="execution_date", limit=1000, order="asc", kwargs...)
+    stock_splits_url = "$stock_splits_base_url"
+    params = Dict(
+        "ticker" => stocksTicker,
+        "apiKey" => opts.api_key,
+        "limit" => limit
+    )
+
+    kwargs = Dict(String(k)=>v for (k,v) in pairs(Dict(kwargs)))
+
+    merge!(params, Dict(kwargs))
 
     return generate_output_from_url(YesSinkYesResults(), stock_splits_url, params, opts.sink)
 end
@@ -280,9 +288,18 @@ julia> stock_dividends(opts, "AAPL")
  * A JSON3.Array or specified tabular representation of the JSON3.Array.
  * See https://polygon.io/docs/get_v2_reference_dividends__stocksTicker__anchor for documentation on response attributes and supported keyword arguments.
 """
-function stock_dividends(opts::PolyOpts, stocksTicker::AbstractString)
-    stock_dividends_url = "$stock_dividends_base_url/$stocksTicker"
-    params = Dict("apiKey" => opts.api_key)
+function stock_dividends(opts::PolyOpts, stocksTicker::AbstractString; limit=1000, kwargs...)
+    stock_dividends_url = "$stock_dividends_base_url"
+
+    params = Dict(
+        "ticker" => stocksTicker,
+        "apiKey" => opts.api_key,
+        "limit" => limit
+    )
+
+    kwargs = Dict(String(k)=>v for (k,v) in pairs(Dict(kwargs)))
+
+    merge!(params, Dict(kwargs))
 
     return generate_output_from_url(YesSinkYesResults(), stock_dividends_url, params, opts.sink)
 end

--- a/src/urls.jl
+++ b/src/urls.jl
@@ -21,7 +21,7 @@ crypto_exchanges_base_url = "https://api.polygon.io/v1/meta/crypto-exchanges"
 
 ticker_details_base_url = "https://api.polygon.io/v1/meta/symbols"
 
-ticker_details_vX_base_url = "https://api.polygon.io/vX/reference/tickers"
+ticker_details_v3_base_url = "https://api.polygon.io/v3/reference/tickers"
 
 stock_splits_base_url = "https://api.polygon.io/v3/reference/splits"
 

--- a/src/urls.jl
+++ b/src/urls.jl
@@ -23,9 +23,9 @@ ticker_details_base_url = "https://api.polygon.io/v1/meta/symbols"
 
 ticker_details_vX_base_url = "https://api.polygon.io/vX/reference/tickers"
 
-stock_splits_base_url = "https://api.polygon.io/v2/reference/splits"
+stock_splits_base_url = "https://api.polygon.io/v3/reference/splits"
 
-stock_dividends_base_url = "https://api.polygon.io/v2/reference/dividends"
+stock_dividends_base_url = "https://api.polygon.io/v3/reference/dividends"
 
 stock_financials_base_url = "https://api.polygon.io/v2/reference/financials"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,15 +6,15 @@ using Test
 
 dotenv()
 
-const API_KEY = ENV["API_KEY"]
+const API_KEY = ENV["POLYGON_API_KEY"]
 const tabular_opts = PolyOpts(API_KEY, Table)
 const regular_opts = PolyOpts(API_KEY, nothing)
 
 
 @testset "Reference API" begin
     # tickets test
-    @test tickers(tabular_opts, "bitcoin") |> length == 10
-    @test tickers(regular_opts, "bitcoin") |> length == 10
+    @test tickers(tabular_opts, "bitcoin") |> length == 34
+    @test tickers(regular_opts, "bitcoin") |> length == 34
 
     # ticker_types test
     @test ticker_types(tabular_opts) |> length == 2
@@ -22,15 +22,15 @@ const regular_opts = PolyOpts(API_KEY, nothing)
 
     # ticker_details test
     @test ticker_details(tabular_opts, "AAPL") |> length == 1
-    @test ticker_details(regular_opts, "AAPL") |> length >= 28
+    @test ticker_details(regular_opts, "AAPL") |> length == 28
 
-    # ticker_details_vX next version test
-    @test ticker_details_vX(tabular_opts, "AAPL", "2019-07-31") |> length == 1
-    @test ticker_details_vX(regular_opts, "AAPL", "2019-07-31") |> length == 20
+    # ticker_details_v3 next version test
+    @test ticker_details_v3(tabular_opts, "AAPL", "2019-07-31") |> length == 1
+    @test ticker_details_v3(regular_opts, "AAPL", "2019-07-31") |> length == 20
 
     # ticker_news test
-    @test ticker_news(tabular_opts, "AAPL") |> length == 10
-    @test ticker_news(regular_opts, "AAPL") |> length == 10
+    @test ticker_news(tabular_opts, "AAPL") |> length >= 11313
+    @test ticker_news(regular_opts, "AAPL") |> length >= 11313
 
     # markets test
     @test markets(regular_opts) |> length >= 7
@@ -42,13 +42,13 @@ const regular_opts = PolyOpts(API_KEY, nothing)
 
     # stock_splits test
     params = Dict(Symbol("execution_date.gte") => "2000-01-01", Symbol("execution_date.lte") => "2020-01-01")
-    @test stock_splits(regular_opts, "AAPL";  params...) |> length == 3
-    @test stock_splits(regular_opts, "AAPL";  params...) |> length == 3
+    @test stock_splits(regular_opts, "AAPL"; params...) |> length == 3
+    @test stock_splits(regular_opts, "AAPL"; params...) |> length == 3
 
     # stock_dividends test
-    params = Dict(Symbol("ex_dividend_date.gte") => "2000-01-01", Symbol("ex_dividend_date.lte") => "2020-01-01")
-    @test stock_dividends(regular_opts, "AAPL"; params...) |> length == 30
-    @test stock_dividends(tabular_opts, "AAPL"; params...) |> length == 30
+    params = Dict(:ticker => "AAPL", Symbol("ex_dividend_date.gte") => "2000-01-01", Symbol("ex_dividend_date.lte") => "2020-01-01")
+    @test stock_dividends(regular_opts; params...) |> length == 30
+    @test stock_dividends(tabular_opts; params...) |> length == 30
 
     # stock_financials test
     @test stock_financials(regular_opts, "AAPL") |> length == 5

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,7 +26,7 @@ const regular_opts = PolyOpts(API_KEY, nothing)
 
     # ticker_details_vX next version test
     @test ticker_details_vX(tabular_opts, "AAPL", "2019-07-31") |> length == 1
-    @test ticker_details_vX(regular_opts, "AAPL", "2019-07-31") |> length == 19
+    @test ticker_details_vX(regular_opts, "AAPL", "2019-07-31") |> length == 20
 
     # ticker_news test
     @test ticker_news(tabular_opts, "AAPL") |> length == 10
@@ -41,12 +41,14 @@ const regular_opts = PolyOpts(API_KEY, nothing)
     @test locales(tabular_opts) |> length >= 19
 
     # stock_splits test
-    @test stock_splits(regular_opts, "AAPL") |> length >= 4
-    @test stock_splits(tabular_opts, "AAPL") |> length >= 4
+    params = Dict(Symbol("execution_date.gte") => "2000-01-01" )
+    @test stock_splits(regular_opts, "AAPL";  params) |> length >= 4
+    @test stock_splits(regular_opts, "AAPL";  params) |> length >= 4
 
     # stock_dividends test
-    @test stock_dividends(regular_opts, "AAPL") |> length >= 65
-    @test stock_dividends(tabular_opts, "AAPL") |> length >= 65
+    params = Dict(Symbol("ex_dividend_date.gte") => "2000-01-01")
+    @test stock_dividends(regular_opts, "AAPL"; params) |> length >= 65
+    @test stock_dividends(tabular_opts, "AAPL"; params) |> length >= 65
 
     # stock_financials test
     @test stock_financials(regular_opts, "AAPL") |> length == 5

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,14 +41,14 @@ const regular_opts = PolyOpts(API_KEY, nothing)
     @test locales(tabular_opts) |> length >= 19
 
     # stock_splits test
-    params = Dict(Symbol("execution_date.gte") => "2000-01-01" )
-    @test stock_splits(regular_opts, "AAPL";  params) |> length >= 4
-    @test stock_splits(regular_opts, "AAPL";  params) |> length >= 4
+    params = Dict(Symbol("execution_date.gte") => "2000-01-01", Symbol("execution_date.lte") => "2020-01-01")
+    @test stock_splits(regular_opts, "AAPL";  params...) |> length == 3
+    @test stock_splits(regular_opts, "AAPL";  params...) |> length == 3
 
     # stock_dividends test
-    params = Dict(Symbol("ex_dividend_date.gte") => "2000-01-01")
-    @test stock_dividends(regular_opts, "AAPL"; params) |> length >= 65
-    @test stock_dividends(tabular_opts, "AAPL"; params) |> length >= 65
+    params = Dict(Symbol("ex_dividend_date.gte") => "2000-01-01", Symbol("ex_dividend_date.lte") => "2020-01-01")
+    @test stock_dividends(regular_opts, "AAPL"; params...) |> length == 30
+    @test stock_dividends(tabular_opts, "AAPL"; params...) |> length == 30
 
     # stock_financials test
     @test stock_financials(regular_opts, "AAPL") |> length == 5


### PR DESCRIPTION
I wasn't sure how to handle keyword arguments with periods in them like `ex_dividend_date.gte` so I came up with this solution. 